### PR TITLE
Fix VS2010 build error

### DIFF
--- a/src/dotnetCampus.LargeAddressAware/Assets/build/PackageId.props
+++ b/src/dotnetCampus.LargeAddressAware/Assets/build/PackageId.props
@@ -1,4 +1,4 @@
-<Project>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>

--- a/src/dotnetCampus.LargeAddressAware/Assets/build/PackageId.targets
+++ b/src/dotnetCampus.LargeAddressAware/Assets/build/PackageId.targets
@@ -1,4 +1,4 @@
-<Project>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>


### PR DESCRIPTION
解决VS2010中编译报错“项目的默认 XML 命名空间必须为 MSBuild XML 命名空间。”。